### PR TITLE
Fix header typo

### DIFF
--- a/credentials/HealthchecksIOApi.credentials.ts
+++ b/credentials/HealthchecksIOApi.credentials.ts
@@ -22,9 +22,9 @@ export class HealthchecksIOApi implements ICredentialType {
 	authenticate: IAuthenticateGeneric = {
 		type: 'generic',
 		properties: {
-			headers: {
-				'X-Custom-Header': 'n8n-ndoes-healthchecksio'
-			},
+                        headers: {
+                                'X-Custom-Header': 'n8n-nodes-healthchecksio'
+                        },
 		},
 	};
 


### PR DESCRIPTION
## Summary
- fix the `X-Custom-Header` value in HealthchecksIO credential

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run build` *(fails: cannot find module 'n8n-workflow')*

------
https://chatgpt.com/codex/tasks/task_b_687ef8305d008326915c98bb2f41a71b