### PR TITLE
Add request body support for Healthchecks.io pings

### DIFF
--- a/nodes/Healthchecksio/CommonFields.ts
+++ b/nodes/Healthchecksio/CommonFields.ts
@@ -67,4 +67,43 @@ export const commonFields: INodeProperties[] = [
     },
     type: 'string',
   },
+  {
+    displayName: 'Request Body',
+    name: 'requestBody',
+    default: '',
+    hint: 'Optional payload to include in the ping request body',
+    displayOptions: {
+      show: {
+        resource: ['by_uuid', 'by_slug'],
+        operation: ['ping', 'start', 'fail', 'log', 'exitStatus'],
+      },
+    },
+    type: 'string',
+    typeOptions: {
+      rows: 4,
+    },
+  },
+  {
+    displayName: 'Content Type',
+    name: 'contentType',
+    default: 'text/plain',
+    description: 'Content-Type header used when sending a request body',
+    displayOptions: {
+      show: {
+        resource: ['by_uuid', 'by_slug'],
+        operation: ['ping', 'start', 'fail', 'log', 'exitStatus'],
+      },
+    },
+    type: 'options',
+    options: [
+      {
+        name: 'Plain Text',
+        value: 'text/plain',
+      },
+      {
+        name: 'JSON',
+        value: 'application/json',
+      },
+    ],
+  },
 ];

--- a/nodes/Healthchecksio/Healthchecksio.node.ts
+++ b/nodes/Healthchecksio/Healthchecksio.node.ts
@@ -31,7 +31,6 @@ export class Healthchecksio implements INodeType {
 			url: '',
 			headers: {
 				Accept: 'application/json',
-				'Content-Type': 'application/json',
 			},
 		},
 		properties: [

--- a/nodes/Healthchecksio/resources/ExitStatusOperation.ts
+++ b/nodes/Healthchecksio/resources/ExitStatusOperation.ts
@@ -8,11 +8,15 @@ export const exitStatusOperation: INodePropertyOptions = {
   routing: {
     request: {
       url: '={{$parameter.uuid ?? ($parameter.pingKey + "/" + $parameter.slug)}}/{{$parameter.exitCode}}',
-      method: 'GET',
+      method: '={{$parameter.requestBody ? "POST" : "GET"}}',
       qs: {
         'create': '={{$parameter.createIfNotExists ? 1 : 0}}',
         'rid': '={{$parameter.runId}}',
       },
+      headers: {
+        'Content-Type': '={{$parameter.requestBody ? $parameter.contentType : undefined}}',
+      },
+      body: '={{$parameter.requestBody}}',
     },
   },
 };

--- a/nodes/Healthchecksio/resources/FailOperation.ts
+++ b/nodes/Healthchecksio/resources/FailOperation.ts
@@ -8,11 +8,15 @@ export const failOperation: INodePropertyOptions = {
   routing: {
     request: {
       url: '={{$parameter.uuid ?? ($parameter.pingKey + "/" + $parameter.slug)}}/fail',
-      method: 'GET',
+      method: '={{$parameter.requestBody ? "POST" : "GET"}}',
       qs: {
         'create': '={{$parameter.createIfNotExists ? 1 : 0}}',
         'rid': '={{$parameter.runId}}',
       },
+      headers: {
+        'Content-Type': '={{$parameter.requestBody ? $parameter.contentType : undefined}}',
+      },
+      body: '={{$parameter.requestBody}}',
     },
   },
 };

--- a/nodes/Healthchecksio/resources/LogOperation.ts
+++ b/nodes/Healthchecksio/resources/LogOperation.ts
@@ -13,9 +13,10 @@ export const logOperation: INodePropertyOptions = {
         'create': '={{$parameter.createIfNotExists ? 1 : 0}}',
         'rid': '={{$parameter.runId}}',
       },
-      body: {
-        'msg': '={{$parameter.logMessage}}',
+      headers: {
+        'Content-Type': '={{$parameter.contentType}}',
       },
+      body: '={{$parameter.requestBody || $parameter.logMessage}}',
     },
   },
 };
@@ -32,6 +33,5 @@ export const logFields: INodeProperties[] = [
       },
     },
     type: 'string',
-    required: true,
   },
 ];

--- a/nodes/Healthchecksio/resources/StartOperation.ts
+++ b/nodes/Healthchecksio/resources/StartOperation.ts
@@ -8,11 +8,15 @@ export const startOperation: INodePropertyOptions = {
   routing: {
     request: {
       url: '={{$parameter.uuid ?? ($parameter.pingKey + "/" + $parameter.slug)}}/start',
-      method: 'GET',
+      method: '={{$parameter.requestBody ? "POST" : "GET"}}',
       qs: {
         'create': '={{$parameter.createIfNotExists ? 1 : 0}}',
         'rid': '={{$parameter.runId}}',
       },
+      headers: {
+        'Content-Type': '={{$parameter.requestBody ? $parameter.contentType : undefined}}',
+      },
+      body: '={{$parameter.requestBody}}',
     },
   },
 };

--- a/nodes/Healthchecksio/resources/SuccessPingOperation.ts
+++ b/nodes/Healthchecksio/resources/SuccessPingOperation.ts
@@ -8,11 +8,15 @@ export const successPingOperation: INodePropertyOptions = {
   routing: {
     request: {
       url: '={{$parameter.uuid ?? ($parameter.pingKey + "/" + $parameter.slug)}}',
-      method: 'GET',
+      method: '={{$parameter.requestBody ? "POST" : "GET"}}',
       qs: {
         'create': '={{$parameter.createIfNotExists ? 1 : 0}}',
         'rid': '={{$parameter.runId}}',
       },
+      headers: {
+        'Content-Type': '={{$parameter.requestBody ? $parameter.contentType : undefined}}',
+      },
+      body: '={{$parameter.requestBody}}',
     },
   },
 };


### PR DESCRIPTION
## Summary
- add optional request body and content type controls to Healthchecks.io node operations
- send POST pings when a request body is provided and remove default JSON content type
- support raw log payloads alongside legacy log messages

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6949f0065c9c8326a52a2c1e7559d3dd)