### PR TITLE
Send Healthchecks bodies as raw payloads

### DIFF
--- a/nodes/Healthchecksio/CommonFields.ts
+++ b/nodes/Healthchecksio/CommonFields.ts
@@ -67,4 +67,20 @@ export const commonFields: INodeProperties[] = [
     },
     type: 'string',
   },
+  {
+    displayName: 'Request Body',
+    name: 'requestBody',
+    default: '',
+    hint: 'Optional payload to include in the ping request body',
+    displayOptions: {
+      show: {
+        resource: ['by_uuid', 'by_slug'],
+        operation: ['ping', 'start', 'fail', 'log', 'exitStatus'],
+      },
+    },
+    type: 'string',
+    typeOptions: {
+      rows: 4,
+    },
+  },
 ];

--- a/nodes/Healthchecksio/Healthchecksio.node.ts
+++ b/nodes/Healthchecksio/Healthchecksio.node.ts
@@ -31,7 +31,6 @@ export class Healthchecksio implements INodeType {
 			url: '',
 			headers: {
 				Accept: 'application/json',
-				'Content-Type': 'application/json',
 			},
 		},
 		properties: [

--- a/nodes/Healthchecksio/resources/ExitStatusOperation.ts
+++ b/nodes/Healthchecksio/resources/ExitStatusOperation.ts
@@ -7,12 +7,13 @@ export const exitStatusOperation: INodePropertyOptions = {
   description: 'Sends a success or failure signal depending on the exit status',
   routing: {
     request: {
-      url: '={{$parameter.uuid ?? ($parameter.pingKey + "/" + $parameter.slug)}}/{{$parameter.exitCode}}',
-      method: 'GET',
+      url: '=/ping/{{$parameter.uuid ?? ($parameter.pingKey + "/" + $parameter.slug)}}/{{$parameter.exitCode}}',
+      method: 'POST',
       qs: {
-        'create': '={{$parameter.createIfNotExists ? 1 : 0}}',
-        'rid': '={{$parameter.runId}}',
+        'create': '={{$parameter.resource === "by_slug" && $parameter.createIfNotExists ? 1 : undefined}}',
+        'rid': '={{$parameter.runId || undefined}}',
       },
+      body: '={{$parameter.requestBody || undefined}}',
     },
   },
 };

--- a/nodes/Healthchecksio/resources/FailOperation.ts
+++ b/nodes/Healthchecksio/resources/FailOperation.ts
@@ -7,12 +7,13 @@ export const failOperation: INodePropertyOptions = {
   description: 'Signals to Healthchecks.io that the job has failed',
   routing: {
     request: {
-      url: '={{$parameter.uuid ?? ($parameter.pingKey + "/" + $parameter.slug)}}/fail',
-      method: 'GET',
+      url: '=/ping/{{$parameter.uuid ?? ($parameter.pingKey + "/" + $parameter.slug)}}/fail',
+      method: 'POST',
       qs: {
-        'create': '={{$parameter.createIfNotExists ? 1 : 0}}',
-        'rid': '={{$parameter.runId}}',
+        'create': '={{$parameter.resource === "by_slug" && $parameter.createIfNotExists ? 1 : undefined}}',
+        'rid': '={{$parameter.runId || undefined}}',
       },
+      body: '={{$parameter.requestBody || undefined}}',
     },
   },
 };

--- a/nodes/Healthchecksio/resources/LogOperation.ts
+++ b/nodes/Healthchecksio/resources/LogOperation.ts
@@ -7,15 +7,13 @@ export const logOperation: INodePropertyOptions = {
   description: 'Sends logging information to Healthchecks.io without signaling success or failure',
   routing: {
     request: {
-      url: '={{$parameter.uuid ?? ($parameter.pingKey + "/" + $parameter.slug)}}/log',
+      url: '=/ping/{{$parameter.uuid ?? ($parameter.pingKey + "/" + $parameter.slug)}}/log',
       method: 'POST',
       qs: {
-        'create': '={{$parameter.createIfNotExists ? 1 : 0}}',
-        'rid': '={{$parameter.runId}}',
+        'create': '={{$parameter.resource === "by_slug" && $parameter.createIfNotExists ? 1 : undefined}}',
+        'rid': '={{$parameter.runId || undefined}}',
       },
-      body: {
-        'msg': '={{$parameter.logMessage}}',
-      },
+      body: '={{$parameter.requestBody || $parameter.logMessage || undefined}}',
     },
   },
 };
@@ -32,6 +30,5 @@ export const logFields: INodeProperties[] = [
       },
     },
     type: 'string',
-    required: true,
   },
 ];

--- a/nodes/Healthchecksio/resources/StartOperation.ts
+++ b/nodes/Healthchecksio/resources/StartOperation.ts
@@ -7,12 +7,13 @@ export const startOperation: INodePropertyOptions = {
   description: 'Signals to Healthchecks.io that the job has started',
   routing: {
     request: {
-      url: '={{$parameter.uuid ?? ($parameter.pingKey + "/" + $parameter.slug)}}/start',
-      method: 'GET',
+      url: '=/ping/{{$parameter.uuid ?? ($parameter.pingKey + "/" + $parameter.slug)}}/start',
+      method: 'POST',
       qs: {
-        'create': '={{$parameter.createIfNotExists ? 1 : 0}}',
-        'rid': '={{$parameter.runId}}',
+        'create': '={{$parameter.resource === "by_slug" && $parameter.createIfNotExists ? 1 : undefined}}',
+        'rid': '={{$parameter.runId || undefined}}',
       },
+      body: '={{$parameter.requestBody || undefined}}',
     },
   },
 };

--- a/nodes/Healthchecksio/resources/SuccessPingOperation.ts
+++ b/nodes/Healthchecksio/resources/SuccessPingOperation.ts
@@ -7,12 +7,13 @@ export const successPingOperation: INodePropertyOptions = {
   description: 'Signals to Healthchecks.io that the job is successful',
   routing: {
     request: {
-      url: '={{$parameter.uuid ?? ($parameter.pingKey + "/" + $parameter.slug)}}',
-      method: 'GET',
+      url: '=/ping/{{$parameter.uuid ?? ($parameter.pingKey + "/" + $parameter.slug)}}',
+      method: 'POST',
       qs: {
-        'create': '={{$parameter.createIfNotExists ? 1 : 0}}',
-        'rid': '={{$parameter.runId}}',
+        'create': '={{$parameter.resource === "by_slug" && $parameter.createIfNotExists ? 1 : undefined}}',
+        'rid': '={{$parameter.runId || undefined}}',
       },
+      body: '={{$parameter.requestBody || undefined}}',
     },
   },
 };


### PR DESCRIPTION
## Summary
- remove the content-type selector and stop serializing payloads so ping-related requests send raw bodies
- only attach request bodies when provided across ping, start, fail, exit status, and log operations

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6949f0065c9c8326a52a2c1e7559d3dd)