### PR TITLE
Send raw Healthchecks payloads without extra fields

### DIFF
--- a/nodes/Healthchecksio/CommonFields.ts
+++ b/nodes/Healthchecksio/CommonFields.ts
@@ -67,4 +67,20 @@ export const commonFields: INodeProperties[] = [
     },
     type: 'string',
   },
+  {
+    displayName: 'Request Body',
+    name: 'requestBody',
+    default: '',
+    hint: 'Optional payload to include in the ping request body',
+    displayOptions: {
+      show: {
+        resource: ['by_uuid', 'by_slug'],
+        operation: ['ping', 'start', 'fail', 'log', 'exitStatus'],
+      },
+    },
+    type: 'string',
+    typeOptions: {
+      rows: 4,
+    },
+  },
 ];

--- a/nodes/Healthchecksio/Healthchecksio.node.ts
+++ b/nodes/Healthchecksio/Healthchecksio.node.ts
@@ -2,7 +2,7 @@ import { INodeType, INodeTypeDescription } from 'n8n-workflow';
 import { commonFields } from './CommonFields';
 import { exitStatusFields, exitStatusOperation } from './resources/ExitStatusOperation';
 import { failOperation } from './resources/FailOperation';
-import { logFields, logOperation } from './resources/LogOperation';
+import { logOperation } from './resources/LogOperation';
 import { startOperation } from './resources/StartOperation';
 import { successPingOperation } from './resources/SuccessPingOperation';
 
@@ -26,14 +26,14 @@ export class Healthchecksio implements INodeType {
 				required: true,
 			},
 		],
-		requestDefaults: {
-			baseURL: '={{$credentials?.domain}}',
-			url: '',
-			headers: {
-				Accept: 'application/json',
-				'Content-Type': 'application/json',
-			},
-		},
+                requestDefaults: {
+                        baseURL: '={{$credentials?.domain}}',
+                        url: '',
+                        headers: {
+                                Accept: 'application/json',
+                        },
+                        json: false,
+                },
 		properties: [
 			{
 				displayName: 'Resource',
@@ -76,8 +76,7 @@ export class Healthchecksio implements INodeType {
 			},
 
 			...commonFields,
-			...logFields,
-			...exitStatusFields,
+                        ...exitStatusFields,
 
 		],
 	};

--- a/nodes/Healthchecksio/resources/ExitStatusOperation.ts
+++ b/nodes/Healthchecksio/resources/ExitStatusOperation.ts
@@ -1,4 +1,4 @@
-import { INodeProperties, INodePropertyOptions } from "n8n-workflow";
+import { IHttpRequestOptions, INodeProperties, INodePropertyOptions } from "n8n-workflow";
 
 export const exitStatusOperation: INodePropertyOptions = {
   name: 'Exit Status',
@@ -7,12 +7,23 @@ export const exitStatusOperation: INodePropertyOptions = {
   description: 'Sends a success or failure signal depending on the exit status',
   routing: {
     request: {
-      url: '={{$parameter.uuid ?? ($parameter.pingKey + "/" + $parameter.slug)}}/{{$parameter.exitCode}}',
-      method: 'GET',
+      url: '=/ping/{{$parameter.uuid ?? ($parameter.pingKey + "/" + $parameter.slug)}}/{{$parameter.exitCode}}',
+      method: 'POST',
       qs: {
-        'create': '={{$parameter.createIfNotExists ? 1 : 0}}',
-        'rid': '={{$parameter.runId}}',
+        'create': '={{$parameter.resource === "by_slug" && $parameter.createIfNotExists ? 1 : undefined}}',
+        'rid': '={{$parameter.runId || undefined}}',
       },
+      body: '={{$parameter.requestBody || undefined}}',
+    },
+    send: {
+      preSend: [
+        async function (requestOptions: IHttpRequestOptions) {
+          if (requestOptions.body !== undefined) {
+            requestOptions.json = false;
+          }
+          return requestOptions;
+        },
+      ],
     },
   },
 };

--- a/nodes/Healthchecksio/resources/FailOperation.ts
+++ b/nodes/Healthchecksio/resources/FailOperation.ts
@@ -1,4 +1,4 @@
-import { INodePropertyOptions } from "n8n-workflow";
+import { IHttpRequestOptions, INodePropertyOptions } from "n8n-workflow";
 
 export const failOperation: INodePropertyOptions = {
   name: 'Fail',
@@ -7,12 +7,23 @@ export const failOperation: INodePropertyOptions = {
   description: 'Signals to Healthchecks.io that the job has failed',
   routing: {
     request: {
-      url: '={{$parameter.uuid ?? ($parameter.pingKey + "/" + $parameter.slug)}}/fail',
-      method: 'GET',
+      url: '=/ping/{{$parameter.uuid ?? ($parameter.pingKey + "/" + $parameter.slug)}}/fail',
+      method: 'POST',
       qs: {
-        'create': '={{$parameter.createIfNotExists ? 1 : 0}}',
-        'rid': '={{$parameter.runId}}',
+        'create': '={{$parameter.resource === "by_slug" && $parameter.createIfNotExists ? 1 : undefined}}',
+        'rid': '={{$parameter.runId || undefined}}',
       },
+      body: '={{$parameter.requestBody || undefined}}',
+    },
+    send: {
+      preSend: [
+        async function (requestOptions: IHttpRequestOptions) {
+          if (requestOptions.body !== undefined) {
+            requestOptions.json = false;
+          }
+          return requestOptions;
+        },
+      ],
     },
   },
 };

--- a/nodes/Healthchecksio/resources/StartOperation.ts
+++ b/nodes/Healthchecksio/resources/StartOperation.ts
@@ -1,4 +1,4 @@
-import { INodePropertyOptions } from "n8n-workflow";
+import { IHttpRequestOptions, INodePropertyOptions } from "n8n-workflow";
 
 export const startOperation: INodePropertyOptions = {
   name: 'Start',
@@ -7,12 +7,23 @@ export const startOperation: INodePropertyOptions = {
   description: 'Signals to Healthchecks.io that the job has started',
   routing: {
     request: {
-      url: '={{$parameter.uuid ?? ($parameter.pingKey + "/" + $parameter.slug)}}/start',
-      method: 'GET',
+      url: '=/ping/{{$parameter.uuid ?? ($parameter.pingKey + "/" + $parameter.slug)}}/start',
+      method: 'POST',
       qs: {
-        'create': '={{$parameter.createIfNotExists ? 1 : 0}}',
-        'rid': '={{$parameter.runId}}',
+        'create': '={{$parameter.resource === "by_slug" && $parameter.createIfNotExists ? 1 : undefined}}',
+        'rid': '={{$parameter.runId || undefined}}',
       },
+      body: '={{$parameter.requestBody || undefined}}',
+    },
+    send: {
+      preSend: [
+        async function (requestOptions: IHttpRequestOptions) {
+          if (requestOptions.body !== undefined) {
+            requestOptions.json = false;
+          }
+          return requestOptions;
+        },
+      ],
     },
   },
 };

--- a/nodes/Healthchecksio/resources/SuccessPingOperation.ts
+++ b/nodes/Healthchecksio/resources/SuccessPingOperation.ts
@@ -1,4 +1,4 @@
-import { INodePropertyOptions } from "n8n-workflow";
+import { IHttpRequestOptions, INodePropertyOptions } from "n8n-workflow";
 
 export const successPingOperation: INodePropertyOptions = {
   name: 'Success Ping',
@@ -7,12 +7,23 @@ export const successPingOperation: INodePropertyOptions = {
   description: 'Signals to Healthchecks.io that the job is successful',
   routing: {
     request: {
-      url: '={{$parameter.uuid ?? ($parameter.pingKey + "/" + $parameter.slug)}}',
-      method: 'GET',
+      url: '=/ping/{{$parameter.uuid ?? ($parameter.pingKey + "/" + $parameter.slug)}}',
+      method: 'POST',
       qs: {
-        'create': '={{$parameter.createIfNotExists ? 1 : 0}}',
-        'rid': '={{$parameter.runId}}',
+        'create': '={{$parameter.resource === "by_slug" && $parameter.createIfNotExists ? 1 : undefined}}',
+        'rid': '={{$parameter.runId || undefined}}',
       },
+      body: '={{$parameter.requestBody || undefined}}',
+    },
+    send: {
+      preSend: [
+        async function (requestOptions: IHttpRequestOptions) {
+          if (requestOptions.body !== undefined) {
+            requestOptions.json = false;
+          }
+          return requestOptions;
+        },
+      ],
     },
   },
 };


### PR DESCRIPTION
## Summary
- remove the unused log message field so logging uses the single request body input
- disable JSON handling globally and before requests so bodies are sent as raw payloads
- simplify request configuration by dropping the lingering content-type option and sticking to raw body handling

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6949f0065c9c8326a52a2c1e7559d3dd)